### PR TITLE
Parse Parameters in URL / Incorperated Middleware

### DIFF
--- a/edulink/Controllers/SiteController.php
+++ b/edulink/Controllers/SiteController.php
@@ -23,6 +23,15 @@ class SiteController
 
     public function about()
     {
+        var_dump('this is the about method');
+    }
+
+    public function foo(Request $request)
+    {
         var_dump('this is the foo method');
+        echo '<pre>';
+        var_dump($request->getRouteParams());
+        echo '</pre>';
+        exit;
     }
 }

--- a/framework/Http/Request.php
+++ b/framework/Http/Request.php
@@ -9,6 +9,8 @@ namespace JonathanRayln\Framework\Http;
  */
 class Request
 {
+    private array $routeParams = [];
+
     /**
      * Gets the current request method.  If a custom method has been set
      * via a POST request, that value is used, otherwise the value is taken
@@ -43,5 +45,29 @@ class Request
     public static function isPost(): bool
     {
         return Application::$app->request->method() === 'POST';
+    }
+
+    /**
+     * Sets route parameters passed through the url to be accessed using the
+     * getRouteParams() method.
+     *
+     * @param array $routeParams Parsed route params created by the Router.
+     * @return $this
+     */
+    public function setRouteParams(array $routeParams): static
+    {
+        $this->routeParams = $routeParams;
+        return $this;
+    }
+
+    /**
+     * Gets stored $routeParams created by the Router from passing parameters
+     * through the URL.
+     *
+     * @return array
+     */
+    public function getRouteParams(): array
+    {
+        return $this->routeParams;
     }
 }

--- a/framework/Http/Router.php
+++ b/framework/Http/Router.php
@@ -81,7 +81,6 @@ class Router
     public function resolve()
     {
         $callback = $this->routes[$this->request->method()][$this->request->path()] ?? false;
-        $middleware = $callback['middleware'] ?? null;
 
         if (!$callback) {
 
@@ -99,7 +98,7 @@ class Router
         $callback['controller'][0] = $controller;
 
         // Resolve the specified middleware (default if none is specified).
-        Middleware::resolve($middleware);
+        Middleware::resolve($callback['middleware']);
 
         return call_user_func([$callback['controller'][0], $callback['controller'][1]], $this->request, $this->response);
     }

--- a/framework/Http/Router.php
+++ b/framework/Http/Router.php
@@ -71,17 +71,17 @@ class Router
         return $this->add('PUT', $path, $controller, $middleware);
     }
 
+    /**
+     * Resolves the current URL to the $routes[] map and parses any parameters
+     * passed.
+     *
+     * @throws \Exception An exception is thrown if middleware is specified in
+     *                    the route that does not exist.
+     */
     public function resolve()
     {
         $callback = $this->routes[$this->request->method()][$this->request->path()] ?? false;
-
-        echo '<pre style="color: red">' . __FILE__ . ' (' . __LINE__ . ')</pre>';
-        echo '<pre>';
-        print_r($callback);
-        echo '</pre>';
-
-        $middleware = $route['middleware'] ?? null;
-
+        $middleware = $callback['middleware'] ?? null;
 
         if (!$callback) {
 
@@ -93,20 +93,13 @@ class Router
             }
         }
 
-        echo '<pre style="color: red">' . __FILE__ . ' (' . __LINE__ . ')</pre>';
-        echo '<pre>';
-        print_r($callback);
-        echo '</pre>';
-
         // Instantiate the controller
         $controller = new $callback['controller'][0]();
         // Put the controller object back into the $callback
         $callback['controller'][0] = $controller;
 
-        echo '<pre style="color: red">' . __FILE__ . ' (' . __LINE__ . ')</pre>';
-        echo '<pre>';
-        print_r($callback);
-        echo '</pre>';
+        // Resolve the specified middleware (default if none is specified).
+        Middleware::resolve($middleware);
 
         return call_user_func([$callback['controller'][0], $callback['controller'][1]], $this->request, $this->response);
     }

--- a/framework/Middleware/Auth.php
+++ b/framework/Middleware/Auth.php
@@ -15,6 +15,6 @@ class Auth implements MiddlewareInterface
      */
     public function handle(): void
     {
-        // TODO: Implement handle() method.
+        var_dump('this is the auth middleware');
     }
 }

--- a/framework/Middleware/Guest.php
+++ b/framework/Middleware/Guest.php
@@ -15,6 +15,6 @@ class Guest implements MiddlewareInterface
      */
     public function handle(): void
     {
-        // TODO: Implement handle() method.
+        var_dump('this is the guest middleware');
     }
 }

--- a/framework/Middleware/Middleware.php
+++ b/framework/Middleware/Middleware.php
@@ -10,8 +10,8 @@ namespace JonathanRayln\Framework\Middleware;
 class Middleware
 {
     /** @var string Default middleware to apply if none is specified. */
-    public const DEFAULT_MIDDLEWARE = 'default';
-    
+    public const DEFAULT_MIDDLEWARE = 'guest';
+
     /** @var array[] Associative array of middleware classes to apply. */
     public const MAP = [
         'auth'  => Auth::class,

--- a/public/index.php
+++ b/public/index.php
@@ -19,17 +19,12 @@ $app->router->get('/', [SiteController::class, 'index']);
 $app->router->post('/', [SiteController::class, 'index']);
 
 // standard action
-$app->router->get('/about', [SiteController::class, 'about']);
+$app->router->get('/about', [SiteController::class, 'about'], 'middlewareadfadfdf');
 // optional variable
-$app->router->get('/about/{id:\+d}', [SiteController::class, 'individual']);
+$app->router->get('/about/{id:\d+}/{username}', [SiteController::class, 'foo'], 'autadfadfh');
+$app->router->get('/about/{username}', [SiteController::class, 'foo'], 'autadfadfh');
 // No action
 $app->router->get('/help', [SiteController::class]);
 
 
 $app->run();
-?>
-
-<form method="post">
-    <input type="text" name="myname">
-    <button type="submit">Submit</button>
-</form>

--- a/public/index.php
+++ b/public/index.php
@@ -19,10 +19,10 @@ $app->router->get('/', [SiteController::class, 'index']);
 $app->router->post('/', [SiteController::class, 'index']);
 
 // standard action
-$app->router->get('/about', [SiteController::class, 'about'], 'authsd');
+$app->router->get('/about', [SiteController::class, 'about'], 'auth');
 // optional variable
-$app->router->get('/about/{id:\d+}/{username}', [SiteController::class, 'foo'], 'autadfadfh');
-$app->router->get('/about/{username}', [SiteController::class, 'foo'], 'autadfadfh');
+$app->router->get('/about/{id:\d+}/{username}', [SiteController::class, 'foo']);
+$app->router->get('/about/{username}', [SiteController::class, 'foo']);
 // No action
 $app->router->get('/help', [SiteController::class]);
 

--- a/public/index.php
+++ b/public/index.php
@@ -19,7 +19,7 @@ $app->router->get('/', [SiteController::class, 'index']);
 $app->router->post('/', [SiteController::class, 'index']);
 
 // standard action
-$app->router->get('/about', [SiteController::class, 'about'], 'middlewareadfadfdf');
+$app->router->get('/about', [SiteController::class, 'about'], 'authsd');
 // optional variable
 $app->router->get('/about/{id:\d+}/{username}', [SiteController::class, 'foo'], 'autadfadfh');
 $app->router->get('/about/{username}', [SiteController::class, 'foo'], 'autadfadfh');


### PR DESCRIPTION
This update adds the ability to pass parameters through the URL via wildcards in the routes.

Route parameters can be added using a variety of either variable names or variable names followed by a colon and a regex pattern to match.
```php
$app->router->get('/login/{id:\d+}/{username}', [AuthController::class, 'login']);
```

Middleware can be specified by adding a third parameter to the route as shown:
```php
$app->router->get('/login/{id:\d+}/{username}', [AuthController::class, 'login'], 'guest');
```

If left `null`, the default middleware is applied as defined in `public const DEFAULT_MIDDLEWARE = 'default';` within the new `framework/Middleware/Middleware.php` class.

Middleware is defined in the `MAP` constant within the new `framework/Middleware/Middleware.php` class as shown below:
```php
/** @var array[] Associative array of middleware classes to apply. */
public const MAP = [
    'auth'  => Auth::class,
    'guest' => Guest::class
];
```